### PR TITLE
Add error inspection supported by newest locks version.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,5 +1,5 @@
 {erl_opts, [debug_info]}.
 {deps, [
-    {locks, {git, "https://github.com/uwiger/locks.git", {ref, "8e9b2e3"}}}
+    {locks, {git, "https://github.com/uwiger/locks.git", {ref, "9ea07d9"}}}
     %{locks, {git, "https://github.com/uwiger/locks.git", {ref, "c9b585a"}}}
 ]}.

--- a/src/asg_manager.erl
+++ b/src/asg_manager.erl
@@ -35,7 +35,28 @@ stop() ->
     locks_leader:call(asg_manager, stop).
 
 is_leader() ->
-    locks_leader:call(asg_manager, is_leader).
+    T0 = erlang:system_time(millisecond),
+    Ns0 = nodes(),
+    try
+        locks_leader:call(asg_manager, is_leader, 60000)
+    catch
+        error:E ->
+            {error, E, #{t0 => T0,
+                         ns0 => Ns0,
+                         ns1 => ns1(Ns0)}, locks_window:fetch_log(asg_manager)};
+        exit:E ->
+            {error, E, #{t0 => T0,
+                         ns0 => Ns0,
+                         ns1 => ns1(Ns0)}, locks_window:fetch_log(asg_manager)}
+    end.
+
+ns1(Ns0) ->
+    case nodes() of
+        Ns0 ->
+            same;
+        Ns ->
+            Ns
+    end.
 
 %% cluster_nodes() ->
 %%     [list_to_atom(lists:concat(["n", "@", Host])) ||


### PR DESCRIPTION
Some changes introduced to better debug hangings.
The `locks` dep is changed to the latest commit (still in a separate branch), and
if the tests are run with `LOCKS_DEBUG=1 make run`, sliding-window message locks can be scraped from the locks_leaders via `process_info()`.

My feeling from running the tests for some hours is that the timeouts still seen are caused by many nodes coming online at the same time, possibly overwhelming at least my laptop. Thus, the test freezes and the leader election doesn't proceed fast enough for it to converge before the timeout.